### PR TITLE
2025s first update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ celerybeat-schedule
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,19 @@ repos:
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
--   repo: https://github.com/psf/black
-    rev: 24.10.0
+
+# -   repo: https://github.com/psf/black
+#     rev: 24.8.0
+#     hooks:
+#     -   id: black
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.8.4
     hooks:
-    -   id: black
+    # Run the linter.
+    # - id: ruff
+    #   args: [ --fix ]
+    # Run the formatter.
+    - id: ruff-format
+      args: [ --line-length=98 ]

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.9
+py-version=3.12
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/.pylintrc
+++ b/.pylintrc
@@ -89,7 +89,7 @@ persistent=yes
 
 # Minimum Python version to use for version dependent checks. Will default to
 # the version used to run pylint.
-py-version=3.12
+py-version=3.9
 
 # Discover python modules and packages in the file system subtree.
 recursive=no

--- a/bluepy3/__init__.py
+++ b/bluepy3/__init__.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
 
-# FIXME: proper __init__
-# try:
-#     from . import btle
-#     from . import helpermaker
-# except ImportError:
-#     import btle
-#     import helpermaker
+from . import btle, helpermaker
 
-# __all__: list[str] = ["btle", "helpermaker"]
+__all__: list[str] = ["btle", "helpermaker"]

--- a/bluepy3/bluepy3-helper.c
+++ b/bluepy3/bluepy3-helper.c
@@ -665,8 +665,18 @@ static void char_desc_cb(uint8_t status, GSList *descriptors, void *user_data) {
   resp_end();
 }
 
+// Define a compile-time constant for the maximum array size
+// Adjust this value based on the maximum expected length of the data
+#define kMaxValueSize 512
+
 static void char_read_cb(guint8 status, const guint8 *pdu, guint16 plen, gpointer user_data) {
-  uint8_t value[plen];
+  if (plen > kMaxValueSize) {
+    DBG("PDU length exceeds maximum value size");
+    resp_error(err_DECODING);
+    return;
+  }
+
+  uint8_t value[kMaxValueSize];  // Use the fixed-size array
   ssize_t vlen;
 
   if (status != 0) {

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -488,8 +488,8 @@ class Bluepy3Helper:
             DBG(f"    -btle- Running {HELPER_PATH}")
             self._lineq = Queue()
             self._mtu = 0
-            # pylint: disable-next=consider-using-with
-            self._stderr = open(os.devnull, "w")  # pylint: disable=unspecified-encoding
+            # pylint: disable-next=consider-using-with, disable-next=unspecified-encoding
+            self._stderr = open(os.devnull, "w")  # noqa: SIM115 (not using a context manager here)
             args: list[str] = [HELPER_PATH]
             if iface is not None:
                 args.append(str(iface))

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -557,7 +557,7 @@ class Bluepy3Helper:
                 return resp
 
             # anything else raises an error or retries
-            if respType == "stat":
+            if respType == "stat":  # noqa: SIM102
                 if "state" in resp and len(resp["state"]) > 0 and resp["state"][0] == "disc":
                     self._stopHelper()
                     raise BTLEConnectError("Device disconnected", resp)

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -310,8 +310,7 @@ class ScanEntry:
     def getScanData(self):
         """Return list of tuples [(tag, description, value)]"""
         return [
-            (sdid, self.getDescription(sdid), self.getValueText(sdid))
-            for sdid in self.scanData.keys()  # pylint: disable=consider-iterating-dictionary
+            (sdid, self.getDescription(sdid), self.getValueText(sdid)) for sdid in self.scanData
         ]
 
     def getValue(self, sdid: int):

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -843,16 +843,14 @@ class Peripheral(Bluepy3Helper):
             ):
                 raise BTLEManagementError("Malformed local OOB data (flags).")
             flags = data[50:51]
-            # fmt: off
             return {
-                "Address": "".join(["%02X" % struct.unpack("<B", c)[0] for c in address]),      # pylint: disable=C0209
-                "Type": "".join(["%02X" % struct.unpack("<B", c)[0] for c in address_type]),    # pylint: disable=C0209
-                "Role": "".join(["%02X" % struct.unpack("<B", c)[0] for c in role]),            # pylint: disable=C0209
-                "C_256": "".join(["%02X" % struct.unpack("<B", c)[0] for c in confirm]),        # pylint: disable=C0209
-                "R_256": "".join(["%02X" % struct.unpack("<B", c)[0] for c in random]),         # pylint: disable=C0209
-                "Flags": "".join(["%02X" % struct.unpack("<B", c)[0] for c in flags]),          # pylint: disable=C0209
+                "Address": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in address]),
+                "Type": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in address_type]),
+                "Role": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in role]),
+                "C_256": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in confirm]),
+                "R_256": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in random]),
+                "Flags": "".join([f"{struct.unpack('<B', c)[0]:02X}" for c in flags]),
             }
-            # fmt: on
         return {}
 
     def getMTU(self) -> int:

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -14,9 +14,10 @@ import struct
 import subprocess  # nosec: B404
 import sys
 import time
+from collections.abc import Generator
 from queue import Empty, Queue
 from threading import Thread
-from typing import Any, Generator, Self, TextIO
+from typing import Any, Self, TextIO
 
 Debugging = False
 SCRIPT_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)))

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -17,7 +17,12 @@ import time
 from collections.abc import Generator
 from queue import Empty, Queue
 from threading import Thread
-from typing import Any, Self, TextIO
+from typing import Any, TextIO
+
+if sys.version_info >= (3, 11):
+    from typing import Self  # code is unreachable in <3.11
+else:
+    from typing_extensions import Self  # code is unreachable in >=3.11
 
 Debugging = False
 SCRIPT_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)))

--- a/bluepy3/btle.py
+++ b/bluepy3/btle.py
@@ -9,7 +9,8 @@
 import binascii
 import json
 import os
-import signal
+
+# import signal
 import struct
 import subprocess  # nosec: B404
 import sys
@@ -58,10 +59,10 @@ ADDR_TYPE_RANDOM = "random"
 BTLE_TIMEOUT = 32.1
 
 
-def preexec_function() -> None:
-    # Ignore the SIGINT signal by setting the handler to the standard
-    # signal handler SIG_IGN.
-    signal.signal(signal.SIGINT, signal.SIG_IGN)
+# def preexec_function() -> None:
+#     # Ignore the SIGINT signal by setting the handler to the standard
+#     # signal handler SIG_IGN.
+#     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 
 def DBG(*args) -> None:
@@ -498,15 +499,15 @@ class Bluepy3Helper:
             if iface is not None:
                 args.append(str(iface))
 
-            # FIXME: should not be using preexec_fn
-            # pylint: disable-next=consider-using-with, disable-next=W1509
+            # pylint: disable-next=consider-using-with
             self._helper = subprocess.Popen(
                 args,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=self._stderr,
                 universal_newlines=True,
-                preexec_fn=preexec_function,
+                # preexec_fn=preexec_function,  # should not be using preexec_fn; pylint W1509
+                start_new_session=True,  # Replaces preexec_fn
             )
             t = Thread(target=self._readToQueue)
             t.daemon = True  # don't wait for it to exit

--- a/bluepy3/get_services.py
+++ b/bluepy3/get_services.py
@@ -74,9 +74,7 @@ def get_table_rows(html=None):
     # service_table=soup.find("table",
     #                         attrs={"summary":"Documents This library contains Services."})
     try:
-        for row in biggest_table.find_all(
-            "tr"
-        ):  # noqa : "Cannot find reference 'find_all' in 'Sized | int'"
+        for row in biggest_table.find_all("tr"):  # noqa : "Cannot find reference 'find_all' in 'Sized | int'"
             cols = row.find_all("td")
             cols = [ele.text.strip() for ele in cols]
             outrow = [ele for ele in cols if ele]  # Get rid of empty values

--- a/bluepy3/helpermaker.py
+++ b/bluepy3/helpermaker.py
@@ -69,9 +69,7 @@ def get_btctl_version() -> str:
     args: list[str] = ["bluetoothctl", "version"]
     try:
         _exit_code = (
-            subprocess.check_output(
-                args, shell=False, encoding="utf-8", timeout=5.0
-            )  # nosec B603
+            subprocess.check_output(args, shell=False, encoding="utf-8", timeout=5.0)  # nosec B603
             .strip("\n")
             .strip("'")
         ).split()
@@ -139,7 +137,7 @@ def build_helper() -> None:
         verfile.write(f'#define VERSION_STRING "{BUILD_VERSION}"\n')
 
     # read the Makefile
-    with open(MAKEFILE, "r", encoding="utf-8") as makefile:
+    with open(MAKEFILE, encoding="utf-8") as makefile:
         lines: list[str] = makefile.readlines()
     # write the Makefile while inserting the desired BLUEZ_VERSION
     with open(MAKEFILE, "w", encoding="utf-8") as makefile:

--- a/bluepy3/helpermaker.py
+++ b/bluepy3/helpermaker.py
@@ -20,9 +20,9 @@ import subprocess  # nosec: B404
 import sys
 
 try:
-    import tomllib as tl
+    import tomllib as tl  # type: ignore[import-not-found]
 except ModuleNotFoundError:
-    import tomli as tl  # type: ignore[no-redef]
+    import tomli as tl  # required by python <3.11
 
 # We distinguish between three versions:
 # VERSION

--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - pipdeptree
   - pre-commit
   - pylint
+  - typing-extensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "bluepy3"
 version = "2.17.1"  # latest test version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = "MIT"
 # license-files = { paths = ["LICENSE"] }
 authors = [
@@ -32,11 +32,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: C",
     "Topic :: Home Automation"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bluepy3"
 # version = "2.16.1"  # latest/current distribution version
-version = "2.17.3"  # latest test version
+version = "2.17.4"  # latest test version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,7 +134,7 @@ fix = true
 indent-width = 4
 line-length = 98
 output-format = "concise"
-include = ["pyproject.toml", "bin/**/*.py"]
+include = ["pyproject.toml", "bluepy3/**/*.py"]
 
 [tool.ruff.format]
 indent-style = "space"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "bluepy3"
-version = "2.16.1"  # latest/current distribution version
-# version = "2.15.1"  # latest test version
+# version = "2.16.1"  # latest/current distribution version
+version = "2.17.1"  # latest test version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bluepy3"
 # version = "2.16.1"  # latest/current distribution version
-version = "2.17.2"  # latest test version
+version = "2.17.3"  # latest test version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,5 +129,27 @@ convention = "google"
 match = ".*\\.py"
 add-ignore = "D"
 
+[tool.ruff]
+fix = true
+indent-width = 4
+line-length = 98
+output-format = "concise"
+include = ["pyproject.toml", "bin/**/*.py"]
+
+[tool.ruff.format]
+indent-style = "space"
+line-ending = "auto"
+quote-style = "preserve"
+
+[tool.ruff.lint]
+select = ["B", "E", "F", "I", "SIM", "UP", "W"]
+ignore = [
+    # line too long: formatter is leading
+    "E501"
+    ]
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["ALL"]
+unfixable = []
+
 
 # pylint is controlled by .pylintrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "hatchling.build"
 [project]
 name = "bluepy3"
 # version = "2.16.1"  # latest/current distribution version
-version = "2.17.1"  # latest test version
+version = "2.17.2"  # latest test version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -68,6 +68,7 @@ include = [
 "./pyproject.toml" = "bluepy3/pyproject.toml"
 
 [tool.autopep8]
+python_version = "3.9"
 max_line_length = 98
 in-place = true
 recursive = true
@@ -89,11 +90,12 @@ skips = [
 
 [tool.black]
 line-length = 98
+required-version = ">=3.9"
 target-version = ["py39", "py310", "py311", "py312", "py313"]
 
 [tool.isort]
 profile = "black"
-py_version="auto"
+py_version = "39"
 
 [tool.flake8]
 max_line_length = 98
@@ -111,6 +113,7 @@ ignore = [
     ]
 
 [tool.mypy]
+python_version = "3.9"
 warn_return_any = true
 warn_unused_configs = true
 warn_redundant_casts = true
@@ -130,6 +133,7 @@ match = ".*\\.py"
 add-ignore = "D"
 
 [tool.ruff]
+target-version = "py39"
 fix = true
 indent-width = 4
 line-length = 98


### PR DESCRIPTION
* fixes #32 
* introducing `ruff` to replace/complement various formatters and linters.
* changing some type-hints to repair broken support of Python 3.9
* deprecating support for Python 3.8 since this is now EOL.
* adding "support" for Python 3.13
* for now development is (still) done using Python 3.9 (with testing on Python 3.12 using a Raspberry Pi 3B).
