### PR TITLE
Fix license SPDX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ version = "2.22.3"  # latest/current distribution version
 description = "A Python3 module for interfacing with Bluetooth LE devices on Linux."
 readme = "README.md"
 requires-python = ">=3.9"
-license = "MIT"
+license = "MIT AND AGPL-3.0-or-later"
 # license-files = { paths = ["LICENSE"] }
 authors = [
     { name="Mausy5043" },
@@ -29,8 +29,6 @@ keywords = [
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
-    "License :: OSI Approved :: MIT License",
-    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
According to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license, the license should be a SPDX format and right now it only shows "MIT", which can lead to confusion with the license in the repo being listed as AGPL. The classifiers for the license are deprecated as well, and removing it because it was also classified as GPL instead of AGPL, leading to more confusion.